### PR TITLE
[Fix for #10] - Limiting username to accomodate 16 characters and roomkey to accept 8 characters

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -15,14 +15,14 @@
             <form id="playForm" action="/" method="POST">
                 <div class="box">
                     <label id="userLabel">Username</label>
-                    <input class="input-box" type="text" name="username" id="username" autocomplete="off" required>
+                    <input class="input-box" type="text" name="username" id="username" autocomplete="off" maxlength="16" required>
                 </div>
                 <div class="box">
                     <label id="roomLabel">Room Key</label>
                     <% if(roomKey === undefined) {%>
-                        <input class="input-box" type="text" name="roomKey" id="roomKey" autocomplete="off" required>
+                        <input class="input-box" type="text" name="roomKey" id="roomKey" autocomplete="off" maxlength="8" required>
                     <% } else { %>
-                        <input class="input-box" value="<%= roomKey %>" type="text" name="roomKey" id="roomKey" autocomplete="off" required>
+                        <input class="input-box" value="<%= roomKey %>" type="text" name="roomKey" id="roomKey" autocomplete="off" maxlength="8" required>
                     <% } %>
                 </div>
                 <button class="white-button" id="playButton">PLAY</button>


### PR DESCRIPTION
This PR addresses https://github.com/notvalproate/Algo-Game/issues/10.

In order to limit the username and room key input fields to accept only 16 and 8 characters respectively, I have used the `maxlength` attribute to implement the required limitation.

Previously:

`<input class="input-box" type="text" name="username" id="username" autocomplete="off" required>`
`<input class="input-box" type="text" name="roomKey" id="roomKey" autocomplete="off" required>`
`<input class="input-box" value="<%= roomKey %>" type="text" name="roomKey" id="roomKey" autocomplete="off" required>`

Now:

`<input class="input-box" type="text" name="username" id="username" autocomplete="off" maxlength="16" required>`
`<input class="input-box" type="text" name="roomKey" id="roomKey" autocomplete="off" maxlength="8" required>`
`<input class="input-box" value="<%= roomKey %>" type="text" name="roomKey" id="roomKey" autocomplete="off" maxlength="8" required>`

I request you to share your thoughts on whether this change does the trick.