### PR TITLE
Added german option to language settings

### DIFF
--- a/public/dev/js/language.js
+++ b/public/dev/js/language.js
@@ -1,6 +1,6 @@
 const languageModal = $("#language-modal");
 
-const supportedLanguages = ["en", "it", "ja"];
+const supportedLanguages = ["de", "en", "it", "ja"];
 
 function addLanguageEventListeners(tempFunction) {
     $("#languageButton").click(() => {

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -52,6 +52,9 @@
             <span class="select-lang" id="selectLang">SELECT LANGUAGE</span>
             <hr class="white-hr">
             <ul class="lang-options">
+                <li class="white-button lang-option" id="deOption">
+                    Deutsch
+                </li>
                 <li class="white-button lang-option" id="enOption">
                     English
                 </li>

--- a/views/play.ejs
+++ b/views/play.ejs
@@ -165,6 +165,9 @@
             <span class="select-lang" id="selectLang">SELECT LANGUAGE</span>
             <hr class="white-hr">
             <ul class="lang-options">
+                <li class="white-button lang-option" id="deOption">
+                    Deutsch
+                </li>
                 <li class="white-button lang-option" id="enOption">
                     English
                 </li>


### PR DESCRIPTION
## Description
Added German option as **Deutsch** in the language settings

## Changes Made
- Added the option to select **Deutsch** in the language settings in both `index.ejs` and `play.ejs`
- Added `de` to supported languages in `languages.js`

## Testing
Tested working of the language setting. Successfully sets the language to german for all the fields.

## Additional Context
Waiting on @Mega-NKE for translation file proofread by a native. Will change translations accordingly.

- [X] I am still working on this PR and it is not ready to be merged
